### PR TITLE
Fixed: Should use $PSScriptRoot instead os $PSScriptPath

### DIFF
--- a/StashTagSkins.ps1
+++ b/StashTagSkins.ps1
@@ -57,7 +57,7 @@ catch {
 }
 
 #Find the Library Root
-$LibraryRoot = "$psscriptpath$($directorySlash)Library"
+$LibraryRoot = "$psscriptroot$($directorySlash)Library"
 if (!(test-path "$LibraryRoot"))
 {
     $LibraryRoot = ".$($directorySlash)Library"


### PR DESCRIPTION
When running this on MacOS, I noticed it was traversing the OS-native `/Library` folder, not one relative to the script.  When looking at the code, I found it was due to an incorrect variable when building the file path.